### PR TITLE
Fix root calculation for quadratic polys without linear term

### DIFF
--- a/src/main/java/com/numericalmethod/suanshu/analysis/function/polynomial/root/QuadraticRoot.java
+++ b/src/main/java/com/numericalmethod/suanshu/analysis/function/polynomial/root/QuadraticRoot.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (c) Numerical Method Inc.
  * http://www.numericalmethod.com/
- * 
+ *
  * THIS SOFTWARE IS LICENSED, NOT SOLD.
- * 
+ *
  * YOU MAY USE THIS SOFTWARE ONLY AS DESCRIBED IN THE LICENSE.
  * IF YOU ARE NOT AWARE OF AND/OR DO NOT AGREE TO THE TERMS OF THE LICENSE,
  * DO NOT USE THIS SOFTWARE.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITH NO WARRANTY WHATSOEVER,
  * EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION,
  * ANY WARRANTIES OF ACCURACY, ACCESSIBILITY, COMPLETENESS,
  * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, NON-INFRINGEMENT,
  * TITLE AND USEFULNESS.
- * 
+ *
  * IN NO EVENT AND UNDER NO LEGAL THEORY,
  * WHETHER IN ACTION, CONTRACT, NEGLIGENCE, TORT, OR OTHERWISE,
  * SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
@@ -104,7 +104,7 @@ public class QuadraticRoot implements PolyRootSolver {
          */
         if (compare(e, 0, Constant.EPSILON) >= 0) {
             // real roots
-            d = -signum(b_OVER_2) * d;
+            if (b_OVER_2 != 0) { d = -signum(b_OVER_2) * d; }
             double x1 = (-b_OVER_2 + d) / a;
             roots.add(x1);
             roots.add(!isZero(x1, 0) ? (c / x1) / a : 0.0);

--- a/src/test/java/com/numericalmethod/suanshu/analysis/function/polynomial/root/QuadraticRootTest.java
+++ b/src/test/java/com/numericalmethod/suanshu/analysis/function/polynomial/root/QuadraticRootTest.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (c) Numerical Method Inc.
  * http://www.numericalmethod.com/
- * 
+ *
  * THIS SOFTWARE IS LICENSED, NOT SOLD.
- * 
+ *
  * YOU MAY USE THIS SOFTWARE ONLY AS DESCRIBED IN THE LICENSE.
  * IF YOU ARE NOT AWARE OF AND/OR DO NOT AGREE TO THE TERMS OF THE LICENSE,
  * DO NOT USE THIS SOFTWARE.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITH NO WARRANTY WHATSOEVER,
  * EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION,
  * ANY WARRANTIES OF ACCURACY, ACCESSIBILITY, COMPLETENESS,
  * FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, NON-INFRINGEMENT,
  * TITLE AND USEFULNESS.
- * 
+ *
  * IN NO EVENT AND UNDER NO LEGAL THEORY,
  * WHETHER IN ACTION, CONTRACT, NEGLIGENCE, TORT, OR OTHERWISE,
  * SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
@@ -60,6 +60,22 @@ public class QuadraticRootTest {
         Polynomial polynomial = new Polynomial(1, 0, 1); // x^2 + 1
         List<Number> roots = instance.solve(polynomial);
         assertEquals(Arrays.asList(Complex.I, Complex.I.opposite()), roots);
+    }
+
+    @Test
+    public void test_solve_zero_b_real_roots() {
+        QuadraticRoot instance = new QuadraticRoot();
+        Polynomial polynomial = new Polynomial(13, 0, -1); // 13x^2 - 1
+        List<Number> roots = instance.solve(polynomial);
+        NumberAssert.assertSameList(Arrays.asList(-1 / Math.sqrt(13), 1 / Math.sqrt(13)), roots, 0);
+    }
+
+    @Test
+    public void test_solve_positive_b() {
+        QuadraticRoot instance = new QuadraticRoot();
+        Polynomial polynomial = new Polynomial(1, 5, 6); // x^2 + 5x + 6
+        List<Number> roots = instance.solve(polynomial);
+        NumberAssert.assertSameList(Arrays.asList(-3, -2), roots, 1e-15);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
An unchecked signum multiplication in `analysis.function.polynomial.root.QuadraticRoot` causes the solver to always report a double root at `0` whenever the linear coefficient of a quadratic polynomial is `0`. This PR adds a guard to ensure that the correct roots are returned.